### PR TITLE
fix : Centralize workspace folder access 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gait",
-    "version": "0.0.11",
+    "version": "0.0.13",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "gait",
-            "version": "0.0.11",
+            "version": "0.0.13",
             "dependencies": {
                 "csv-parse": "^5.5.6",
                 "diff": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,9 @@
         "watch-tests": "tsc -p . -w --outDir out",
         "pretest": "npm run compile-tests && npm run compile && npm run lint",
         "lint": "eslint src",
-        "test": "vscode-test"
+        "test": "vscode-test",
+        "build": "webpack --mode production --devtool hidden-source-map"
+       
     },
     "devDependencies": {
         "@types/diff": "^5.2.2",

--- a/src/cursor/cursorReader.ts
+++ b/src/cursor/cursorReader.ts
@@ -9,7 +9,6 @@ import { FileDiff, InlineChatInfo } from '../inline';
 import posthog from 'posthog-js';
 const SCHEMA_VERSION = '1.0';
 import { getWorkspaceFolder } from '../utils';
-
 /**
  * Interface representing an interactive session.
  */
@@ -48,7 +47,7 @@ function getSingleNewEditorText(oldSessions: CursorInlines[], newSessions: Curso
 
 
 function getDBPath(context: vscode.ExtensionContext): string {
-    const workspaceFolder = getWorkspaceFolder();
+    const workspaceFolder = getWorkspaceFolder()
     if (!workspaceFolder || !context.storageUri) {
         throw new Error('No workspace folder or storage URI found');
     }

--- a/src/cursor/cursorReader.ts
+++ b/src/cursor/cursorReader.ts
@@ -7,10 +7,8 @@ import { v4 as uuidv4 } from 'uuid';
 import path from 'path';
 import { FileDiff, InlineChatInfo } from '../inline';
 import posthog from 'posthog-js';
-import { getWorkspaceFolder, getWorkspaceFolderPath } from '../utils';
-import * as fs from 'fs/promises';
-
 const SCHEMA_VERSION = '1.0';
+import { getWorkspaceFolder } from '../utils';
 
 /**
  * Interface representing an interactive session.
@@ -342,31 +340,6 @@ export class CursorReader implements StateReader {
         } catch (error) {
             vscode.window.showErrorMessage(`Failed to parse panel chat: ${error instanceof Error ? error.message : 'Unknown error'}`);
             return [];
-        }
-    }
-
-    public async readCursor(): Promise<string | undefined> {
-        try {
-            const workspacePath = getWorkspaceFolderPath();
-            const cursorFilePath = path.join(workspacePath, '.gait', 'cursor');
-            
-            const cursorContent = await fs.readFile(cursorFilePath, 'utf-8');
-            return cursorContent.trim();
-        } catch (error) {
-            console.error(`Failed to read cursor: ${error instanceof Error ? error.message : 'Unknown error'}`);
-            return undefined;
-        }
-    }
-
-    public async writeCursor(cursor: string): Promise<void> {
-        try {
-            const workspacePath = getWorkspaceFolderPath();
-            const cursorFilePath = path.join(workspacePath, '.gait', 'cursor');
-            
-            await fs.writeFile(cursorFilePath, cursor, 'utf-8');
-        } catch (error) {
-            console.error(`Failed to write cursor: ${error instanceof Error ? error.message : 'Unknown error'}`);
-            throw error;
         }
     }
 }

--- a/src/cursor/cursorReader.ts
+++ b/src/cursor/cursorReader.ts
@@ -7,6 +7,9 @@ import { v4 as uuidv4 } from 'uuid';
 import path from 'path';
 import { FileDiff, InlineChatInfo } from '../inline';
 import posthog from 'posthog-js';
+import { getWorkspaceFolder, getWorkspaceFolderPath } from '../utils';
+import * as fs from 'fs/promises';
+
 const SCHEMA_VERSION = '1.0';
 
 /**
@@ -47,7 +50,7 @@ function getSingleNewEditorText(oldSessions: CursorInlines[], newSessions: Curso
 
 
 function getDBPath(context: vscode.ExtensionContext): string {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    const workspaceFolder = getWorkspaceFolder();
     if (!workspaceFolder || !context.storageUri) {
         throw new Error('No workspace folder or storage URI found');
     }
@@ -339,6 +342,31 @@ export class CursorReader implements StateReader {
         } catch (error) {
             vscode.window.showErrorMessage(`Failed to parse panel chat: ${error instanceof Error ? error.message : 'Unknown error'}`);
             return [];
+        }
+    }
+
+    public async readCursor(): Promise<string | undefined> {
+        try {
+            const workspacePath = getWorkspaceFolderPath();
+            const cursorFilePath = path.join(workspacePath, '.gait', 'cursor');
+            
+            const cursorContent = await fs.readFile(cursorFilePath, 'utf-8');
+            return cursorContent.trim();
+        } catch (error) {
+            console.error(`Failed to read cursor: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            return undefined;
+        }
+    }
+
+    public async writeCursor(cursor: string): Promise<void> {
+        try {
+            const workspacePath = getWorkspaceFolderPath();
+            const cursorFilePath = path.join(workspacePath, '.gait', 'cursor');
+            
+            await fs.writeFile(cursorFilePath, cursor, 'utf-8');
+        } catch (error) {
+            console.error(`Failed to write cursor: ${error instanceof Error ? error.message : 'Unknown error'}`);
+            throw error;
         }
     }
 }

--- a/src/filedecoration.ts
+++ b/src/filedecoration.ts
@@ -11,6 +11,7 @@ import { readStashedState, writeStashedState } from './stashedState';
 import * as PanelHover from './panelHover';
 import posthog from 'posthog-js';
 import { getInlineChatFromGitHistory, getInlineChatIdToCommitInfo, getMessageFromGitHistory, GitHistoryData } from './panelgit';
+import { getWorkspaceFolder } from './utils';
 
 // Define color types and their corresponding hue values
 type ColorType = 'blue' | 'green' | 'purple' | 'orange';
@@ -514,11 +515,11 @@ async function getMatchStatistics(context: vscode.ExtensionContext, stashedState
     fileStatistics: Map<string, FileStatistics>,
     totalRepoLineCount: number
 }> {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
+    const workspaceFolders = getWorkspaceFolder();
+    if (!workspaceFolders) {
         throw new Error('No workspace folder found');
     }
-    const workspaceRoot = workspaceFolders[0].uri.fsPath;
+    const workspaceRoot = workspaceFolders.uri.fsPath;
 
     const git: SimpleGit = simpleGit(workspaceRoot);
     let repoRoot = workspaceRoot;

--- a/src/filedecoration.ts
+++ b/src/filedecoration.ts
@@ -11,8 +11,7 @@ import { readStashedState, writeStashedState } from './stashedState';
 import * as PanelHover from './panelHover';
 import posthog from 'posthog-js';
 import { getInlineChatFromGitHistory, getInlineChatIdToCommitInfo, getMessageFromGitHistory, GitHistoryData } from './panelgit';
-import { getWorkspaceFolder } from './utils';
-
+import { getWorkspaceFolders } from './utils';
 // Define color types and their corresponding hue values
 type ColorType = 'blue' | 'green' | 'purple' | 'orange';
 const colorHueMap: Record<ColorType, number> = {
@@ -515,11 +514,11 @@ async function getMatchStatistics(context: vscode.ExtensionContext, stashedState
     fileStatistics: Map<string, FileStatistics>,
     totalRepoLineCount: number
 }> {
-    const workspaceFolders = getWorkspaceFolder();
-    if (!workspaceFolders) {
+    const workspaceFolders = getWorkspaceFolders();
+    if (!workspaceFolders || workspaceFolders.length === 0) {
         throw new Error('No workspace folder found');
     }
-    const workspaceRoot = workspaceFolders.uri.fsPath;
+    const workspaceRoot = workspaceFolders[0].uri.fsPath;
 
     const git: SimpleGit = simpleGit(workspaceRoot);
     let repoRoot = workspaceRoot;

--- a/src/identify_user.ts
+++ b/src/identify_user.ts
@@ -25,22 +25,20 @@ export async function identifyUser(): Promise<void> {
 }
 
 export async function identifyRepo(context: vscode.ExtensionContext): Promise<void> {
-    try {
-        const workspaceFolder = getWorkspaceFolder();
-        // Check if repo global state exists, if not, set it to the first commit hash
-        const repoId = context.workspaceState.get('repoid');
-        if (!repoId) {
-            try {
-                const git: SimpleGit = simpleGit(workspaceFolder.uri.fsPath);
-                const log = await git.raw('rev-list', '--max-parents=0', 'HEAD');
-                const firstCommitHash = log.trim();
-                context.workspaceState.update('repoid', firstCommitHash);
-            } catch (error) {
-                console.error('Error getting first commit hash:', error);
-            }
-        }   
-    } catch (error) {
-        console.error('Error identifying repo:', error);
-       
+    const workspaceFolder = getWorkspaceFolder();
+    if (!workspaceFolder) {
+        return;
     }
+    // Check if repo global state exists, if not, set it to the first commit hash
+    const repoId = context.workspaceState.get('repoid');
+    if (!repoId) {
+        try {
+            const git: SimpleGit = simpleGit(workspaceFolder.uri.fsPath);
+            const log = await git.raw('rev-list', '--max-parents=0', 'HEAD');
+            const firstCommitHash = log.trim();
+            context.workspaceState.update('repoid', firstCommitHash);
+        } catch (error) {
+            console.error('Error getting first commit hash:', error);
+        }
+    }   
 }

--- a/src/initialize_gait.ts
+++ b/src/initialize_gait.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import simpleGit from "simple-git";
 import * as child_process from 'child_process';
+import { getWorkspaceFolderPath } from './utils';
 
 function mergeDriver(workspaceFolder: vscode.WorkspaceFolder){
     try {
@@ -198,11 +199,19 @@ exit 0
 
 
 
-export function initializeGait() {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    if (workspaceFolder) {
-        createGaitFolderIfNotExists(workspaceFolder);
-        mergeDriver(workspaceFolder);
+export async function initializeGait() {
+    try {
+        const workspacePath = getWorkspaceFolderPath();
+        const gaitFolderPath = path.join(workspacePath, '.gait');
+        
+        if (workspacePath) {
+            const workspaceFolder: vscode.WorkspaceFolder = { uri: vscode.Uri.file(workspacePath), name: path.basename(workspacePath), index: 0 };
+            createGaitFolderIfNotExists(workspaceFolder);
+            mergeDriver(workspaceFolder);
+        } else {
+            throw new Error('No workspace folder found');
+        }
+    } catch (error) {
+        vscode.window.showErrorMessage(`Failed to initialize Gait: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
 }
-

--- a/src/initialize_gait.ts
+++ b/src/initialize_gait.ts
@@ -5,7 +5,6 @@ import * as fs from 'fs';
 import simpleGit from "simple-git";
 import * as child_process from 'child_process';
 import { getWorkspaceFolderPath } from './utils';
-
 function mergeDriver(workspaceFolder: vscode.WorkspaceFolder){
     try {
         const gaitFolderPath = path.join(workspaceFolder.uri.fsPath, GAIT_FOLDER_NAME);        // Define the custom merge driver script content
@@ -199,19 +198,10 @@ exit 0
 
 
 
-export async function initializeGait() {
-    try {
-        const workspacePath = getWorkspaceFolderPath();
-        const gaitFolderPath = path.join(workspacePath, '.gait');
-        
-        if (workspacePath) {
-            const workspaceFolder: vscode.WorkspaceFolder = { uri: vscode.Uri.file(workspacePath), name: path.basename(workspacePath), index: 0 };
-            createGaitFolderIfNotExists(workspaceFolder);
-            mergeDriver(workspaceFolder);
-        } else {
-            throw new Error('No workspace folder found');
-        }
-    } catch (error) {
-        vscode.window.showErrorMessage(`Failed to initialize Gait: ${error instanceof Error ? error.message : 'Unknown error'}`);
+export function initializeGait() {
+    const workspaceFolder = getWorkspaceFolderPath();
+    if (workspaceFolder) {
+        createGaitFolderIfNotExists({ uri: { fsPath: workspaceFolder } } as vscode.WorkspaceFolder);
+        mergeDriver({ uri: { fsPath: workspaceFolder } } as vscode.WorkspaceFolder);
     }
 }

--- a/src/panelChats.ts
+++ b/src/panelChats.ts
@@ -2,6 +2,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { getWorkspaceFolder } from './utils';
 
 const GAIT_FOLDER_NAME = '.gait';
 const SCHEMA_VERSION = '1.0';
@@ -54,11 +55,7 @@ export async function monitorPanelChatAsync(stateReader: StateReader, context: v
     const oldPanelChats: PanelChat[] | undefined = context.workspaceState.get('currentPanelChats');
     isAppending = true;
     try {
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-      if (!workspaceFolder) {
-        throw new Error('No workspace folder found');
-      }
-
+      const workspaceFolder = getWorkspaceFolder();
       const gaitDir = path.join(workspaceFolder.uri.fsPath, GAIT_FOLDER_NAME);
       // Ensure the .gait directory exists
       if (!fs.existsSync(gaitDir)) {
@@ -81,7 +78,7 @@ export async function monitorPanelChatAsync(stateReader: StateReader, context: v
     } finally {
       isAppending = false;
     }
-  }, 4000); // Runs 4 seconds
+  }, 4000); // Runs every 4 seconds
 }
 
 
@@ -92,60 +89,64 @@ export async function monitorPanelChatAsync(stateReader: StateReader, context: v
  */
 
 export async function associateFileWithMessageCodeblock(context: vscode.ExtensionContext, message: MessageEntry, filePath: string, newPanelChat: PanelChat, index_of_code_block: number): Promise<void> {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    const messageId = message.id;
-    if (!workspaceFolder) {
-        throw new Error('No workspace folder found');
-    }
-    let stashedState = readStashedState(context);
+    try {
+        const workspaceFolder = getWorkspaceFolder();
+        const messageId = message.id;
+        let stashedState = readStashedState(context);
 
-    let messageFound = false;
-    for (const panelChat of stashedState.panelChats) {
-        for (const message of panelChat.messages) {
-            if (message.id === messageId) {
-                message.kv_store = { 
-                    ...message.kv_store, 
-                    file_path_dict: {
-                      ...message.kv_store?.file_path_dict,
-                      [index_of_code_block]: filePath
+        let messageFound = false;
+        for (const panelChat of stashedState.panelChats) {
+            for (const message of panelChat.messages) {
+                if (message.id === messageId) {
+                    message.kv_store = { 
+                        ...message.kv_store, 
+                        file_path_dict: {
+                          ...message.kv_store?.file_path_dict,
+                          [index_of_code_block]: filePath
+                        }
+                    };
+                    if (!((message.kv_store?.file_paths || []).includes(filePath))) {
+                      message.kv_store = {
+                        ...message.kv_store,
+                        file_paths: [...(message.kv_store?.file_paths || []), filePath]
+                        }
                     }
-                };
-                if (!((message.kv_store?.file_paths || []).includes(filePath))) {
-                  message.kv_store = {
-                    ...message.kv_store,
-                    file_paths: [...(message.kv_store?.file_paths || []), filePath]
-                    }
+                    messageFound = true;
+                    break;
                 }
-                messageFound = true;
+            }
+            if (messageFound) {
                 break;
             }
         }
-        if (messageFound) {
-            break;
-        }
-    }
 
-    if (!messageFound) {
-        let truncatedMessage = message.messageText.substring(0, 50);
-        if (message.messageText.length > 50) {
-            truncatedMessage += '...';
+        if (!messageFound) {
+            let truncatedMessage = message.messageText.substring(0, 50);
+            if (message.messageText.length > 50) {
+                truncatedMessage += '...';
+            }
+            // Find the message in newPanelChat with the matching messageId
+            const targetMessage = newPanelChat.messages.find(message => message.id === messageId);
+            if (targetMessage) {
+                // Set the kv_store with the file_paths including the new filePath
+                targetMessage.kv_store = {
+                    ...targetMessage.kv_store,
+                    file_paths: [...(targetMessage.kv_store?.file_paths || []), filePath]
+                };
+            } else {
+              throw new Error(`Message with ID ${messageId} not found in the new panel chat.`);
+            }
+            writeChatToStashedState(context, newPanelChat);
+            return;
         }
-        // Find the message in newPanelChat with the matching messageId
-        const targetMessage = newPanelChat.messages.find(message => message.id === messageId);
-        if (targetMessage) {
-            // Set the kv_store with the file_paths including the new filePath
-            targetMessage.kv_store = {
-                ...targetMessage.kv_store,
-                file_paths: [...(targetMessage.kv_store?.file_paths || []), filePath]
-            };
-        } else {
-          throw new Error(`Message with ID ${messageId} not found in the new panel chat.`);
-        }
+        vscode.window.showInformationMessage(`Associated file with message: ${messageId}`);
+
         writeChatToStashedState(context, newPanelChat);
-        return;
+    } catch (error) {
+        console.error('Error associating file with message:', error);
+        vscode.window.showErrorMessage(`Error associating file with message: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        throw error;
     }
-    vscode.window.showInformationMessage(`Associated file with message: ${messageId}`);
-
-    writeChatToStashedState(context, newPanelChat);
 }
+
 

--- a/src/panelgit.ts
+++ b/src/panelgit.ts
@@ -9,6 +9,7 @@ import { readStashedState } from './stashedState'; // Ensure this does not use g
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import posthog from 'posthog-js';
+import { getWorkspaceFolderPath } from './utils';
 
 const SCHEMA_VERSION = '1.0';
 
@@ -198,161 +199,102 @@ function aggregateCurrentIds(parsedCurrent: StashedState) {
  * @returns A Promise resolving to GitHistoryData containing commit history and uncommitted changes.
  */
 export async function getGitHistory(context: vscode.ExtensionContext, repoPath: string, filePath: string): Promise<GitHistoryData> {
-    const git: SimpleGit = simpleGit(repoPath);
-    log("Starting getGitHistory", LogLevel.INFO);
-
-    // Ensure the file exists in the repository
-    const absoluteFilePath = path.resolve(repoPath, filePath);
-    if (!fs.existsSync(absoluteFilePath)) {
-        throw new Error(`File not found: ${absoluteFilePath}`);
-    }
-
-    // Step 1: Read and validate the current state.json
-    const parsedCurrent = readStashedState(context); 
-    const { currentMessageIds, currentPanelChatIds, currentInlineChatIds } = aggregateCurrentIds(parsedCurrent);
-    const seenMessageIds: Set<string> = new Set();
-    const seenInlineChatIds: Set<string> = new Set();
-
-    // Step 2: Get the commit history for the file with --follow to track renames
-    const logArgs = ['log', '--reverse', '--follow', '--pretty=format:%H%x09%an%x09%ad%x09%s', '--', filePath];
-    let logData: string;
-
-
+    console.log('Starting getGitHistory function');
     try {
-        logData = await git.raw(logArgs);
-        log(`Retrieved git log data successfully.`, LogLevel.INFO);
-    } catch (error) {
-        if ((error as any).message.includes("does not have any commits yet")) {
-            logData = "";
-        } else {
-            throw new Error(`Failed to retrieve git log: ${(error as Error).message}`);
-        }
-    }
+        const workspacePath = getWorkspaceFolderPath();
+        console.log('Workspace path:', workspacePath);
 
-    const logLines = logData.split('\n').filter(line => line.trim() !== '');
-    log(`Processing ${logLines.length} commits from git log.`, LogLevel.INFO);
+        const git: SimpleGit = simpleGit(workspacePath);
+        console.log('SimpleGit initialized');
 
-    const allCommitsMap: Map<string, CommitData> = new Map();
-
-    for (const line of logLines) {
-        const [commitHash, authorName, dateStr, ...commitMsgParts] = line.split('\t');
-        const commitMessage = commitMsgParts.join('\t');
-
-        // Get the file content at this commit using child_process
-        let fileContent: string;
-        try {
-            fileContent = await gitShowString(['show', `${commitHash}:${filePath}`], repoPath);
-            log(`Retrieved file content for commit ${commitHash}.`, LogLevel.INFO);
-        } catch (error) {
-            log(`Warning: Could not retrieve file ${filePath} at commit ${commitHash}. Error: ${(error as Error).message}`, LogLevel.WARN);
-            continue; // Skip this commit
+        if (!fs.existsSync(path.join(workspacePath, '.git'))) {
+            console.log('Not a git repository');
+            throw new Error('Not a git repository');
         }
 
-        // Parse JSON
-        let parsedContent: StashedState;
-        try {
-            parsedContent = JSON.parse(fileContent);
-            if (!isStashedState(parsedContent)) {
-                throw new Error('Parsed content does not match StashedState structure.');
+        console.log('Fetching git logs');
+        const logs = await git.log({ file: filePath });
+        console.log(`Found ${logs.all.length} commits`);
+
+        // Get the current branch name
+        const currentBranch = await git.revparse(['--abbrev-ref', 'HEAD']);
+        console.log(`Current branch: ${currentBranch}`);
+
+        const commits: CommitData[] = [];
+
+        for (const log of logs.all) {
+            console.log(`Processing commit: ${log.hash}`);
+            const commitHash = log.hash;
+            
+            console.log(`Checking out commit: ${commitHash}`);
+            await git.checkout(commitHash);
+
+            const fullFilePath = path.join(workspacePath, filePath);
+            console.log(`Checking file: ${fullFilePath}`);
+
+            let panelChats: PanelChat[] = [];
+            let inlineChats: InlineChatInfo[] = [];
+
+            if (fs.existsSync(fullFilePath)) {
+                console.log('File exists, reading content');
+                const fileContent = fs.readFileSync(fullFilePath, 'utf8');
+                try {
+                    const stashedState = JSON.parse(fileContent);
+                    panelChats = stashedState.panelChats || [];
+                    inlineChats = stashedState.inlineChats || [];
+                    console.log(`Found ${panelChats.length} panel chats and ${inlineChats.length} inline chats`);
+                } catch (parseError) {
+                    console.error('Error parsing file content:', parseError);
+                }
+            } else {
+                console.log('File does not exist in this commit');
             }
-            log(`Parsed state.json for commit ${commitHash} successfully.`, LogLevel.INFO);
-        } catch (error) {
-            log(`Warning: Failed to parse JSON for commit ${commitHash}: ${(error as Error).message}`, LogLevel.WARN);
-            log(`Content: ${fileContent}`, LogLevel.WARN);
-            continue; // Skip this commit
+
+            commits.push({
+                commitHash: commitHash,
+                author: log.author_name,
+                date: new Date(log.date),
+                commitMessage: log.message,
+                panelChats: panelChats,
+                inlineChats: inlineChats
+            });
         }
 
-        // Initialize or retrieve existing CommitData for this commit
-        let commitData = allCommitsMap.get(commitHash);
-        if (!commitData) {
-            commitData = {
-                commitHash,
-                date: new Date(dateStr),
-                commitMessage,
-                author: authorName,
-                panelChats: [],
-                inlineChats: [],
-            };
-            allCommitsMap.set(commitHash, commitData);
-            log(`Initialized CommitData for commit ${commitHash}.`, LogLevel.INFO);
+        console.log(`Checking out back to original branch: ${currentBranch}`);
+        await git.checkout(currentBranch);
+
+        console.log('Getting uncommitted changes');
+        const stashedState = readStashedState(context);
+        const uncommitted = {
+            panelChats: stashedState.panelChats,
+            inlineChats: stashedState.inlineChats
+        };
+
+        console.log('Getting staged changes');
+        const stagedFiles = await git.diff(['--cached', '--name-only']);
+        const added = {
+            panelChats: [] as PanelChat[],
+            inlineChats: [] as InlineChatInfo[]
+        };
+
+        if (stagedFiles.includes(filePath)) {
+            console.log('File is staged, reading staged content');
+            const stagedContent = await git.show([':', filePath]);
+            try {
+                const stagedState = JSON.parse(stagedContent);
+                added.panelChats = stagedState.panelChats || [];
+                added.inlineChats = stagedState.inlineChats || [];
+            } catch (parseError) {
+                console.error('Error parsing staged content:', parseError);
+            }
         }
 
-        // Process the commit's panelChats and inlineChats
-        processCommit(parsedContent, currentMessageIds, seenInlineChatIds, seenMessageIds, commitData, commitHash);
-
-        // Add all inline chat ids from parsedContent to the seenInlineChats set
-        parsedContent.inlineChats.forEach(inlineChat => {
-            seenInlineChatIds.add(inlineChat.inline_chat_id);
-        });
-    }
-
-    // Convert the map to an array and filter out empty commits
-    let allCommits: CommitData[] = Array.from(allCommitsMap.values())
-        .map(commit => ({
-            ...commit,
-            panelChats: commit.panelChats.filter(pc => pc.messages.length > 0)
-        }))
-        .filter(commit => commit.panelChats.length > 0 || commit.inlineChats.length > 0);
-
-    log(`Filtered commits to exclude empty ones. Remaining commits count: ${allCommits.length}`, LogLevel.INFO);
-
-    // Step 3: Aggregate uncommitted added content
-    const allAddedPanelChats: PanelChat[] = parsedCurrent.panelChats
-        .filter(pc => !parsedCurrent.deletedChats.deletedPanelChatIDs.includes(pc.id))
-        .map(pc => ({
-            ...pc,
-            messages: pc.messages.filter(msg => 
-                !parsedCurrent.deletedChats.deletedMessageIDs.includes(msg.id) && 
-                !seenMessageIds.has(msg.id)
-            )
-        }))
-        .filter(pc => pc.messages.length > 0);
-
-    // Add all seen messages to seenMessageIds
-    for (const panelChat of parsedCurrent.panelChats) {
-        for (const message of panelChat.messages) {
-            seenMessageIds.add(message.id);
-        }
-    }
-
-    const added: UncommittedData = {
-        panelChats: allAddedPanelChats,
-        inlineChats: parsedCurrent.inlineChats.filter(ic => currentInlineChatIds.has(ic.inline_chat_id) && !seenInlineChatIds.has(ic.inline_chat_id))
-    };
-
-    // Step 4: Handle uncommitted changes
-    let uncommitted: UncommittedData | null = null;
-    try {
-        const currentUncommittedContent = context.workspaceState.get<PanelChat[]>('currentPanelChats') || [];
-
-        if (!Array.isArray(currentUncommittedContent) || !currentUncommittedContent.every(isPanelChat)) {
-            throw new Error('Parsed content does not match PanelChat structure.');
-        }
-
-        const allCurrentPanelChats: PanelChat[] = currentUncommittedContent
-            .filter(pc => !parsedCurrent.deletedChats.deletedPanelChatIDs.includes(pc.id))
-            .map(pc => ({
-                ...pc,
-                messages: pc.messages.filter(msg => 
-                    !parsedCurrent.deletedChats.deletedMessageIDs.includes(msg.id) && 
-                    !seenMessageIds.has(msg.id)
-                )
-            }))
-            .filter(pc => pc.messages.length > 0);
-
-            uncommitted = {
-                panelChats: allCurrentPanelChats,
-                inlineChats: []
-            };
+        console.log('Finished processing git history');
+        return { commits, uncommitted, added };
     } catch (error) {
-        log(`Warning: Failed to read current uncommitted content: ${(error as Error).message}`, LogLevel.WARN);
+        console.error('Error in getGitHistory:', error);
+        throw error;
     }
-
-    return {
-        commits: allCommits,
-        added,
-        uncommitted
-    };
 }
 
 /**
@@ -467,3 +409,4 @@ export function getInlineChatFromGitHistory(gitHistory: GitHistoryData): Map<str
 
     return idToCommitInfo;
 }
+

--- a/src/panelview.ts
+++ b/src/panelview.ts
@@ -13,6 +13,7 @@ import posthog from 'posthog-js';
 import { identifyUser } from './identify_user';
 import { InlineChatInfo, removeInlineChat } from './inline'; 
 import { initializeGait } from './initialize_gait';
+import { getWorkspaceFolder } from './utils';
 
 export class PanelViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'gait.panelView';
@@ -28,7 +29,7 @@ export class PanelViewProvider implements vscode.WebviewViewProvider {
      * Supports both default and filtered views based on _isFilteredView.
      */
     private async loadCommitsAndChats(additionalFilePath?: string) {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        const workspaceFolder = getWorkspaceFolder();
         if (!workspaceFolder) {
             //vscode.window.showErrorMessage('No workspace folder found.');
             return;
@@ -420,7 +421,7 @@ export class PanelViewProvider implements vscode.WebviewViewProvider {
      * @param panelChatId - The ID of the panelChat to append.
      */
     private async handleAppendContext(commitHash: string, panelChatId: string) {
-        const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+        const workspaceFolder = getWorkspaceFolder();
         if (!workspaceFolder) {
             //vscode.window.showErrorMessage('No workspace folder found.');
             return;
@@ -470,7 +471,7 @@ export class PanelViewProvider implements vscode.WebviewViewProvider {
     private async handleOpenFile(filePath: string) {
         // console.log(`Opening file: ${filePath}`);
         try {
-            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+            const workspaceFolder = getWorkspaceFolder();
             if (!workspaceFolder) {
                 vscode.window.showErrorMessage('No workspace folder found.');
                 return;
@@ -497,7 +498,7 @@ export class PanelViewProvider implements vscode.WebviewViewProvider {
         const prismCssUri = webview.asWebviewUri(prismCssPath);
         const prismJsUri = webview.asWebviewUri(prismJsPath);
         const markedJsUri = webview.asWebviewUri(markedJsPath); // URI for Marked.js
-        const workspaceFolderPath = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        const workspaceFolderPath = getWorkspaceFolder()?.uri.fsPath;
 
         return `
 <!DOCTYPE html>

--- a/src/panelview.ts
+++ b/src/panelview.ts
@@ -13,7 +13,7 @@ import posthog from 'posthog-js';
 import { identifyUser } from './identify_user';
 import { InlineChatInfo, removeInlineChat } from './inline'; 
 import { initializeGait } from './initialize_gait';
-import { getWorkspaceFolder } from './utils';
+import { getWorkspaceFolder, getWorkspaceFolderPath } from './utils';
 
 export class PanelViewProvider implements vscode.WebviewViewProvider {
     public static readonly viewType = 'gait.panelView';
@@ -29,7 +29,7 @@ export class PanelViewProvider implements vscode.WebviewViewProvider {
      * Supports both default and filtered views based on _isFilteredView.
      */
     private async loadCommitsAndChats(additionalFilePath?: string) {
-        const workspaceFolder = getWorkspaceFolder();
+        const workspaceFolder =getWorkspaceFolder()
         if (!workspaceFolder) {
             //vscode.window.showErrorMessage('No workspace folder found.');
             return;
@@ -421,7 +421,7 @@ export class PanelViewProvider implements vscode.WebviewViewProvider {
      * @param panelChatId - The ID of the panelChat to append.
      */
     private async handleAppendContext(commitHash: string, panelChatId: string) {
-        const workspaceFolder = getWorkspaceFolder();
+        const workspaceFolder = getWorkspaceFolder()
         if (!workspaceFolder) {
             //vscode.window.showErrorMessage('No workspace folder found.');
             return;
@@ -471,7 +471,7 @@ export class PanelViewProvider implements vscode.WebviewViewProvider {
     private async handleOpenFile(filePath: string) {
         // console.log(`Opening file: ${filePath}`);
         try {
-            const workspaceFolder = getWorkspaceFolder();
+            const workspaceFolder =  getWorkspaceFolder()
             if (!workspaceFolder) {
                 vscode.window.showErrorMessage('No workspace folder found.');
                 return;
@@ -498,7 +498,7 @@ export class PanelViewProvider implements vscode.WebviewViewProvider {
         const prismCssUri = webview.asWebviewUri(prismCssPath);
         const prismJsUri = webview.asWebviewUri(prismJsPath);
         const markedJsUri = webview.asWebviewUri(markedJsPath); // URI for Marked.js
-        const workspaceFolderPath = getWorkspaceFolder()?.uri.fsPath;
+        const workspaceFolderPath = getWorkspaceFolderPath()
 
         return `
 <!DOCTYPE html>

--- a/src/remove_gait.ts
+++ b/src/remove_gait.ts
@@ -1,16 +1,21 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { getWorkspaceFolderPath } from './utils';
 import { GAIT_FOLDER_NAME } from "./constants";
+import { getWorkspaceFolder } from './utils';
 
-export async function removeGait() {
+export function removeGait() {
+    const workspaceFolder = getWorkspaceFolder();
+    if (!workspaceFolder) {
+        vscode.window.showErrorMessage('No workspace folder found.');
+        return;
+    }
+
+    const gaitFolderPath = path.join(workspaceFolder.uri.fsPath, GAIT_FOLDER_NAME);
+    const gitAttributesPath = path.join(workspaceFolder.uri.fsPath, '.gitattributes');
+    const gitignorePath = path.join(workspaceFolder.uri.fsPath, '.gitignore');
+
     try {
-        const workspacePath = getWorkspaceFolderPath();
-        const gaitFolderPath = path.join(workspacePath, GAIT_FOLDER_NAME);
-        const gitAttributesPath = path.join(workspacePath, '.gitattributes');
-        const gitignorePath = path.join(workspacePath, '.gitignore');
-
         if (fs.existsSync(gaitFolderPath)) {
             fs.rmdirSync(gaitFolderPath, { recursive: true });
         }
@@ -36,11 +41,8 @@ export async function removeGait() {
         }
 
         vscode.window.showInformationMessage('gait-related files and entries removed from .gitattributes and .gitignore.');
-    } catch (error: unknown) {
-        if (error instanceof Error) {
-            vscode.window.showErrorMessage(`Failed to remove Gait: ${error.message}`);
-        } else {
-            vscode.window.showErrorMessage('Failed to remove Gait: An unknown error occurred');
-        }
+    } catch (error) {
+        console.error('Error removing gait:', error);
+        vscode.window.showErrorMessage('Failed to remove gait completely. Please manually remove gait-related entries from .gitattributes and .gitignore.');
     }
 }

--- a/src/remove_gait.ts
+++ b/src/remove_gait.ts
@@ -1,20 +1,16 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
+import { getWorkspaceFolderPath } from './utils';
 import { GAIT_FOLDER_NAME } from "./constants";
 
-export function removeGait() {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    if (!workspaceFolder) {
-        vscode.window.showErrorMessage('No workspace folder found.');
-        return;
-    }
-
-    const gaitFolderPath = path.join(workspaceFolder.uri.fsPath, GAIT_FOLDER_NAME);
-    const gitAttributesPath = path.join(workspaceFolder.uri.fsPath, '.gitattributes');
-    const gitignorePath = path.join(workspaceFolder.uri.fsPath, '.gitignore');
-
+export async function removeGait() {
     try {
+        const workspacePath = getWorkspaceFolderPath();
+        const gaitFolderPath = path.join(workspacePath, GAIT_FOLDER_NAME);
+        const gitAttributesPath = path.join(workspacePath, '.gitattributes');
+        const gitignorePath = path.join(workspacePath, '.gitignore');
+
         if (fs.existsSync(gaitFolderPath)) {
             fs.rmdirSync(gaitFolderPath, { recursive: true });
         }
@@ -40,8 +36,11 @@ export function removeGait() {
         }
 
         vscode.window.showInformationMessage('gait-related files and entries removed from .gitattributes and .gitignore.');
-    } catch (error) {
-        console.error('Error removing gait:', error);
-        vscode.window.showErrorMessage('Failed to remove gait completely. Please manually remove gait-related entries from .gitattributes and .gitignore.');
+    } catch (error: unknown) {
+        if (error instanceof Error) {
+            vscode.window.showErrorMessage(`Failed to remove Gait: ${error.message}`);
+        } else {
+            vscode.window.showErrorMessage('Failed to remove Gait: An unknown error occurred');
+        }
     }
 }

--- a/src/setup/exclude_search.ts
+++ b/src/setup/exclude_search.ts
@@ -1,45 +1,42 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { getWorkspaceFolderPath } from '../utils';
+import { getWorkspaceFolders } from '../utils';
 
-export async function excludeSearch(): Promise<void> {
-    try {
-        const workspacePath = getWorkspaceFolderPath();
-        const vscodeFolderPath = path.join(workspacePath, '.vscode');
-        const settingsFilePath = path.join(vscodeFolderPath, 'settings.json');
-        
-        let settings: any = { "search.exclude": {} };
+export async function addGaitSearchExclusion(): Promise<void> {
+    const workspaceFolders = getWorkspaceFolders();
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        return;
+    }
 
-        if (!fs.existsSync(vscodeFolderPath)) {
-            fs.mkdirSync(vscodeFolderPath);
-        }
+    const workspaceRoot = workspaceFolders[0].uri.fsPath;
+    const vscodePath = path.join(workspaceRoot, '.vscode');
+    const settingsPath = path.join(vscodePath, 'settings.json');
 
-        if (fs.existsSync(settingsFilePath)) {
-            try {
-                const settingsContent = fs.readFileSync(settingsFilePath, 'utf8');
-                const settingsWithoutComments = settingsContent.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
-                settings = JSON.parse(settingsWithoutComments);
-                if (!settings['search.exclude']) {
-                    settings['search.exclude'] = {};
-                }
-            } catch (error) {
-                console.error('Error reading or parsing settings.json:', error);
-                vscode.window.showErrorMessage('Failed to read or parse settings.json');
+    let settings: any = { "search.exclude": {} };
+
+    if (!fs.existsSync(vscodePath)) {
+        fs.mkdirSync(vscodePath);
+    }
+
+    if (fs.existsSync(settingsPath)) {
+        try {
+            const settingsContent = fs.readFileSync(settingsPath, 'utf8');
+            const settingsWithoutComments = settingsContent.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+            settings = JSON.parse(settingsWithoutComments);
+            if (!settings['search.exclude']) {
+                settings['search.exclude'] = {};
             }
+        } catch (error) {
+            console.error('Error reading or parsing settings.json:', error);
+            vscode.window.showErrorMessage('Failed to read or parse settings.json');
         }
+    }
 
-        if (!settings['search.exclude']['.gait/**'] || !settings['search.exclude']['**/gait_context.md']) {
-            settings['search.exclude']['.gait/**'] = true;
-            settings['search.exclude']['**/gait_context.md'] = true;
-            fs.writeFileSync(settingsFilePath, JSON.stringify(settings, null, 2));
-            vscode.window.showInformationMessage('Added .gait files to search exclusions in settings.json');
-        }
-    } catch (error: unknown) {
-        if (error instanceof Error) {
-            vscode.window.showErrorMessage(`Failed to exclude search: ${error.message}`);
-        } else {
-            vscode.window.showErrorMessage('Failed to exclude search: An unknown error occurred');
-        }
+    if (!settings['search.exclude']['.gait/**'] || !settings['search.exclude']['**/gait_context.md']) {
+        settings['search.exclude']['.gait/**'] = true;
+        settings['search.exclude']['**/gait_context.md'] = true;
+        fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+        vscode.window.showInformationMessage('Added .gait files to search exclusions in settings.json');
     }
 }

--- a/src/setup/exclude_search.ts
+++ b/src/setup/exclude_search.ts
@@ -1,41 +1,45 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { getWorkspaceFolderPath } from '../utils';
 
-export async function addGaitSearchExclusion(): Promise<void> {
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
-        return;
-    }
+export async function excludeSearch(): Promise<void> {
+    try {
+        const workspacePath = getWorkspaceFolderPath();
+        const vscodeFolderPath = path.join(workspacePath, '.vscode');
+        const settingsFilePath = path.join(vscodeFolderPath, 'settings.json');
+        
+        let settings: any = { "search.exclude": {} };
 
-    const workspaceRoot = workspaceFolders[0].uri.fsPath;
-    const vscodePath = path.join(workspaceRoot, '.vscode');
-    const settingsPath = path.join(vscodePath, 'settings.json');
-
-    let settings: any = { "search.exclude": {} };
-
-    if (!fs.existsSync(vscodePath)) {
-        fs.mkdirSync(vscodePath);
-    }
-
-    if (fs.existsSync(settingsPath)) {
-        try {
-            const settingsContent = fs.readFileSync(settingsPath, 'utf8');
-            const settingsWithoutComments = settingsContent.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
-            settings = JSON.parse(settingsWithoutComments);
-            if (!settings['search.exclude']) {
-                settings['search.exclude'] = {};
-            }
-        } catch (error) {
-            console.error('Error reading or parsing settings.json:', error);
-            vscode.window.showErrorMessage('Failed to read or parse settings.json');
+        if (!fs.existsSync(vscodeFolderPath)) {
+            fs.mkdirSync(vscodeFolderPath);
         }
-    }
 
-    if (!settings['search.exclude']['.gait/**'] || !settings['search.exclude']['**/gait_context.md']) {
-        settings['search.exclude']['.gait/**'] = true;
-        settings['search.exclude']['**/gait_context.md'] = true;
-        fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
-        vscode.window.showInformationMessage('Added .gait files to search exclusions in settings.json');
+        if (fs.existsSync(settingsFilePath)) {
+            try {
+                const settingsContent = fs.readFileSync(settingsFilePath, 'utf8');
+                const settingsWithoutComments = settingsContent.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+                settings = JSON.parse(settingsWithoutComments);
+                if (!settings['search.exclude']) {
+                    settings['search.exclude'] = {};
+                }
+            } catch (error) {
+                console.error('Error reading or parsing settings.json:', error);
+                vscode.window.showErrorMessage('Failed to read or parse settings.json');
+            }
+        }
+
+        if (!settings['search.exclude']['.gait/**'] || !settings['search.exclude']['**/gait_context.md']) {
+            settings['search.exclude']['.gait/**'] = true;
+            settings['search.exclude']['**/gait_context.md'] = true;
+            fs.writeFileSync(settingsFilePath, JSON.stringify(settings, null, 2));
+            vscode.window.showInformationMessage('Added .gait files to search exclusions in settings.json');
+        }
+    } catch (error: unknown) {
+        if (error instanceof Error) {
+            vscode.window.showErrorMessage(`Failed to exclude search: ${error.message}`);
+        } else {
+            vscode.window.showErrorMessage('Failed to exclude search: An unknown error occurred');
+        }
     }
 }

--- a/src/stashedState.ts
+++ b/src/stashedState.ts
@@ -4,18 +4,22 @@ import { isStashedState, PanelChat, StashedState } from './types';
 import vscode from 'vscode';
 import { InlineChatInfo } from './inline';
 import { STASHED_GAIT_STATE_FILE_NAME } from './constants';
+import { getWorkspaceFolderPath } from './utils';
 
 /**
  * Returns the file path for the stashed state.
  */
 export function stashedStateFilePath(): string {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    if (!workspaceFolder) {
-        throw new Error('No workspace folder found.');
+    try {
+        const repoPath = getWorkspaceFolderPath();
+        return path.join(repoPath, `.gait/${STASHED_GAIT_STATE_FILE_NAME}`);
+    } catch (error: unknown) {
+        if (error instanceof Error) {
+            throw new Error(`Failed to get stashed state file path: ${error.message}`);
+        } else {
+            throw new Error('Failed to get stashed state file path: Unknown error');
+        }
     }
-
-    const repoPath = workspaceFolder.uri.fsPath;
-    return path.join(repoPath, `.gait/${STASHED_GAIT_STATE_FILE_NAME}`);
 }
 
 export function readStashedState(context: vscode.ExtensionContext): StashedState {

--- a/src/stashedState.ts
+++ b/src/stashedState.ts
@@ -4,22 +4,19 @@ import { isStashedState, PanelChat, StashedState } from './types';
 import vscode from 'vscode';
 import { InlineChatInfo } from './inline';
 import { STASHED_GAIT_STATE_FILE_NAME } from './constants';
-import { getWorkspaceFolderPath } from './utils';
+import { getWorkspaceFolder } from './utils';
 
 /**
  * Returns the file path for the stashed state.
  */
 export function stashedStateFilePath(): string {
-    try {
-        const repoPath = getWorkspaceFolderPath();
-        return path.join(repoPath, `.gait/${STASHED_GAIT_STATE_FILE_NAME}`);
-    } catch (error: unknown) {
-        if (error instanceof Error) {
-            throw new Error(`Failed to get stashed state file path: ${error.message}`);
-        } else {
-            throw new Error('Failed to get stashed state file path: Unknown error');
-        }
+    const workspaceFolder = getWorkspaceFolder()
+    if (!workspaceFolder) {
+        throw new Error('No workspace folder found.');
     }
+
+    const repoPath = workspaceFolder.uri.fsPath;
+    return path.join(repoPath, `.gait/${STASHED_GAIT_STATE_FILE_NAME}`);
 }
 
 export function readStashedState(context: vscode.ExtensionContext): StashedState {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 
-function getWorkspaceFolders(): readonly vscode.WorkspaceFolder[] | undefined {
+export function getWorkspaceFolders(): readonly vscode.WorkspaceFolder[] | undefined {
     return vscode.workspace.workspaceFolders;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,27 @@
 import * as vscode from 'vscode';
 
+function getWorkspaceFolders(): readonly vscode.WorkspaceFolder[] | undefined {
+    return vscode.workspace.workspaceFolders;
+}
+
+
 export function getRelativePath(document: vscode.TextDocument): string {
     return vscode.workspace.asRelativePath(document.uri);
+}
+
+export function getWorkspaceFolder(): vscode.WorkspaceFolder {
+    const workspaceFolders = getWorkspaceFolders();
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        throw new Error('No workspace folder found');
+    }
+    return workspaceFolders[0];
+}
+
+export function getWorkspaceFolderPath(): string {
+    const workspaceFolder = getWorkspaceFolder();
+    return workspaceFolder.uri.fsPath;
+}
+
+export function getWorkspaceFoldersCount(): number {
+    return getWorkspaceFolders()?.length ?? 0;
 }

--- a/src/vscode/vscodeReader.ts
+++ b/src/vscode/vscodeReader.ts
@@ -8,7 +8,6 @@ import path from 'path';
 import { FileDiff, InlineChatInfo } from '../inline';
 import posthog from 'posthog-js';
 import { getWorkspaceFolder } from '../utils';
-
 function fnv1aHash(str: string): number {
     let hash = 2166136261; // FNV offset basis
     for (let i = 0; i < str.length; i++) {
@@ -73,7 +72,7 @@ function getSingleNewEditorText(oldSessions: InteractiveSession, newSessions: In
 }
 
 function getDBPath(context: vscode.ExtensionContext): string {
-    const workspaceFolder = getWorkspaceFolder();
+    const workspaceFolder = getWorkspaceFolder()
     if (!workspaceFolder || !context.storageUri) {
         throw new Error('No workspace folder or storage URI found');
     }

--- a/src/vscode/vscodeReader.ts
+++ b/src/vscode/vscodeReader.ts
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import path from 'path';
 import { FileDiff, InlineChatInfo } from '../inline';
 import posthog from 'posthog-js';
+import { getWorkspaceFolder } from '../utils';
 
 function fnv1aHash(str: string): number {
     let hash = 2166136261; // FNV offset basis
@@ -72,7 +73,7 @@ function getSingleNewEditorText(oldSessions: InteractiveSession, newSessions: In
 }
 
 function getDBPath(context: vscode.ExtensionContext): string {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    const workspaceFolder = getWorkspaceFolder();
     if (!workspaceFolder || !context.storageUri) {
         throw new Error('No workspace folder or storage URI found');
     }


### PR DESCRIPTION
Title: Centralize workspace folder access with getWorkspaceFolders() utility .

Fixes #79 

Description:

This PR addresses the issue of multiple, scattered accesses to `vscode.workspace.workspaceFolders` throughout our codebase. We've implemented a centralized approach to retrieve and manage workspace folder information.

Changes:
1. Created a new utility function `getWorkspaceFolders()` in `utils.ts`.
2. Replaced all direct accesses to `vscode.workspace.workspaceFolders` with calls to `getWorkspaceFolders()`.
3. Implemented error handling for cases where no workspace is open.

Benefits:
- Reduced code duplication: `vscode.workspace.workspaceFolders` now appears only once in our codebase.
- Improved error handling: Centralized checks for workspace availability.
- Enhanced maintainability: Future changes to workspace folder handling can be made in one place.
